### PR TITLE
FR-284 Added SMS Event: sms_received

### DIFF
--- a/.changeset/busy-hotels-lead.md
+++ b/.changeset/busy-hotels-lead.md
@@ -1,0 +1,5 @@
+---
+"@justcall/justcall-dialer-sdk": minor
+---
+
+feat: Added SMS Event - sms_received

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The `on` method of the `JustCallDialer` class allows you to listen for events em
   - `call-ringing`: Triggered when an incoming/outgoing call starts ringing.
   - `call-answered`: Triggered when an incoming/outgoing call is answered.
   - `call-ended`: Triggered when a incoming/outgoing call ends.
+  - `sms-received`: Triggered when an SMS is received.
 
 - `callback`: A callback function that will be executed when the specified event occurs. The function receives event data as a parameter.
 
@@ -79,6 +80,10 @@ dialer.on("call-answered", (data) => {
 
 dialer.on("call-ended", function (data) {
   console.log("Client receiving call-ended data: ", data);
+});
+
+dialer.on("sms-received", function (data) {
+  console.log("Client receiving sms-received data: ", data);
 });
 ```
 
@@ -232,6 +237,26 @@ This data object is passed to the callback function when a call ends. It contain
 }
 ```
 
+### `SMSReceivedEventData`
+
+This data object is passed to the callback function when an SMS is received. It contains the following properties:
+
+- `message_sid` (string): The unique identifier for the SMS session.
+- `from` (string): The phone number of the sender.
+- `to` (string): The phone number of the receiver.
+- `body` (string): The body of the SMS.
+- `received_at` (string): The date and time when the SMS was received.
+
+```json
+{
+  "message_sid": "",
+  "from": "",
+  "to": "",
+  "body": "",
+  "received_at": ""
+}
+```
+
 ## Justcall Dialer Error Codes
 
 The `JustcallDialerErrorCode` enum provides error codes for handling various scenarios in the JustCall Dialer SDK.
@@ -256,7 +281,7 @@ Please note that @justcall/justcall-dialer-sdk will produce an iframe with the f
 ```html
 <iframe
   allow="microphone; autoplay; clipboard-read; clipboard-write; hid"
-  src="ttps://app.justcall.io/app/macapp/dialer_events"
+  src="https://app.justcall.io/app/macapp/dialer_events"
   style="width='365px' height='610px'"
 >
 </iframe>

--- a/docs/index.html
+++ b/docs/index.html
@@ -225,6 +225,7 @@ const dialer = new JustCallDialer({
           <li><code>call-ringing</code>: Triggered when an incoming/outgoing call starts ringing.</li>
           <li><code>call-answered</code>: Triggered when an incoming/outgoing call is answered.</li>
           <li><code>call-ended</code>: Triggered when a incoming/outgoing call ends.</li>
+          <li><code>sms-received</code>: Triggered when an SMS is received.</li>
         </ul>
       </li>
       <li>
@@ -243,6 +244,10 @@ const dialer = new JustCallDialer({
 </span><span class="code-line line-number" line="9">dialer<span class="token punctuation">.</span><span class="token function">on</span><span class="token punctuation">(</span><span class="token string">"call-ended"</span><span class="token punctuation">,</span> <span class="token keyword">function</span> <span class="token punctuation">(</span>data<span class="token punctuation">)</span> <span class="token punctuation">{</span>
 </span><span class="code-line line-number" line="10">  <span class="token builtin">console</span><span class="token punctuation">.</span><span class="token function">log</span><span class="token punctuation">(</span><span class="token string">"Client receiving call-ended data: "</span><span class="token punctuation">,</span> data<span class="token punctuation">)</span><span class="token punctuation">;</span>
 </span><span class="code-line line-number" line="11"><span class="token punctuation">}</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
+</span><span class="code-line line-number" line="12">
+</span><span class="code-line line-number" line="13">dialer<span class="token punctuation">.</span><span class="token function">on</span><span class="token punctuation">(</span><span class="token string">"sms-received"</span><span class="token punctuation">,</span> <span class="token keyword">function</span> <span class="token punctuation">(</span>data<span class="token punctuation">)</span> <span class="token punctuation">{</span>
+</span><span class="code-line line-number" line="14">  <span class="token builtin">console</span><span class="token punctuation">.</span><span class="token function">log</span><span class="token punctuation">(</span><span class="token string">"Client receiving sms-received data: "</span><span class="token punctuation">,</span> data<span class="token punctuation">)</span><span class="token punctuation">;</span>
+</span><span class="code-line line-number" line="15"><span class="token punctuation">}</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
 </span></code><div onclick="copied(this)" data-code="dialer.on(&#x22;call-ringing&#x22;, (data) => {
   console.log(&#x22;Client receiving call-ringing data: &#x22;, data);
 });
@@ -253,6 +258,10 @@ dialer.on(&#x22;call-answered&#x22;, (data) => {
 
 dialer.on(&#x22;call-ended&#x22;, function (data) {
   console.log(&#x22;Client receiving call-ended data: &#x22;, data);
+});
+
+dialer.on(&#x22;sms-received&#x22;, function (data) {
+  console.log(&#x22;Client receiving sms-received data: &#x22;, data);
 });
 " class="copied"><svg class="octicon-copy" aria-hidden="true" viewBox="0 0 16 16" fill="currentColor" height="12" width="12"><path fill-rule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"></path><path fill-rule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"></path></svg><svg class="octicon-check" aria-hidden="true" viewBox="0 0 16 16" fill="currentColor" height="12" width="12"><path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path></svg></div></pre>
     <h2 id="unsubscribeevent-justcalldialeremittableevent-method"><a class="anchor" aria-hidden="true" tabindex="-1" href="#unsubscribeevent-justcalldialeremittableevent-method"><span class="octicon octicon-link"></span></a><code>unsubscribe(event: JustCallDialerEmittableEvent)</code> method:</h2>
@@ -401,6 +410,30 @@ dialer.dialNumber(&#x22;+1234567890&#x22;);
   &#x22;duration&#x22;: 120
 }
 " class="copied"><svg class="octicon-copy" aria-hidden="true" viewBox="0 0 16 16" fill="currentColor" height="12" width="12"><path fill-rule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"></path><path fill-rule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"></path></svg><svg class="octicon-check" aria-hidden="true" viewBox="0 0 16 16" fill="currentColor" height="12" width="12"><path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path></svg></div></pre>
+    <h3 id="smsreceivedeventdata"><a class="anchor" aria-hidden="true" tabindex="-1" href="#smsreceivedeventdata"><span class="octicon octicon-link"></span></a><code>SMSReceivedEventData</code></h3>
+    <p>This data object is passed to the callback function when an SMS is received. It contains the following properties:</p>
+    <ul>
+      <li><code>message_sid</code> (string): The unique identifier for the SMS session.</li>
+      <li><code>from</code> (string): The phone number of the sender.</li>
+      <li><code>to</code> (string): The phone number of the receiver.</li>
+      <li><code>body</code> (string): The body of the SMS.</li>
+      <li><code>received_at</code> (string): The date and time when the SMS was received.</li>
+    </ul>
+    <pre class="language-json"><code class="language-json code-highlight"><span class="code-line line-number" line="1"><span class="token punctuation">{</span>
+</span><span class="code-line line-number" line="2">  <span class="token property">"message_sid"</span><span class="token operator">:</span> <span class="token string">""</span><span class="token punctuation">,</span>
+</span><span class="code-line line-number" line="3">  <span class="token property">"from"</span><span class="token operator">:</span> <span class="token string">""</span><span class="token punctuation">,</span>
+</span><span class="code-line line-number" line="4">  <span class="token property">"to"</span><span class="token operator">:</span> <span class="token string">""</span><span class="token punctuation">,</span>
+</span><span class="code-line line-number" line="5">  <span class="token property">"body"</span><span class="token operator">:</span> <span class="token string">""</span><span class="token punctuation">,</span>
+</span><span class="code-line line-number" line="6">  <span class="token property">"received_at"</span><span class="token operator">:</span> <span class="token string">""</span>
+</span><span class="code-line line-number" line="7"><span class="token punctuation">}</span>
+</span></code><div onclick="copied(this)" data-code="{
+  &#x22;message_sid&#x22;: &#x22;&#x22;,
+  &#x22;from&#x22;: &#x22;&#x22;,
+  &#x22;to&#x22;: &#x22;&#x22;,
+  &#x22;body&#x22;: &#x22;&#x22;,
+  &#x22;received_at&#x22;: &#x22;&#x22;
+}
+" class="copied"><svg class="octicon-copy" aria-hidden="true" viewBox="0 0 16 16" fill="currentColor" height="12" width="12"><path fill-rule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"></path><path fill-rule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"></path></svg><svg class="octicon-check" aria-hidden="true" viewBox="0 0 16 16" fill="currentColor" height="12" width="12"><path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path></svg></div></pre>
     <h2 id="justcall-dialer-error-codes"><a class="anchor" aria-hidden="true" tabindex="-1" href="#justcall-dialer-error-codes"><span class="octicon octicon-link"></span></a>Justcall Dialer Error Codes</h2>
     <p>The <code>JustcallDialerErrorCode</code> enum provides error codes for handling various scenarios in the JustCall Dialer SDK.</p>
     <h3 id="error-codes"><a class="anchor" aria-hidden="true" tabindex="-1" href="#error-codes"><span class="octicon octicon-link"></span></a>Error Codes:</h3>
@@ -419,13 +452,13 @@ dialer.dialNumber(&#x22;+1234567890&#x22;);
     <p>Please note that @justcall/justcall-dialer-sdk will produce an iframe with the following permissions granted:</p>
     <pre class="language-html"><code class="language-html code-highlight"><span class="code-line line-number" line="1"><span class="token tag"><span class="token tag"><span class="token punctuation">&#x3C;</span>iframe</span>
 </span></span><span class="code-line line-number" line="2"><span class="token tag">  <span class="token attr-name">allow</span><span class="token attr-value"><span class="token punctuation attr-equals">=</span><span class="token punctuation">"</span>microphone; autoplay; clipboard-read; clipboard-write; hid<span class="token punctuation">"</span></span>
-</span></span><span class="code-line line-number" line="3"><span class="token tag">  <span class="token attr-name">src</span><span class="token attr-value"><span class="token punctuation attr-equals">=</span><span class="token punctuation">"</span>ttps://app.justcall.io/app/macapp/dialer_events<span class="token punctuation">"</span></span>
+</span></span><span class="code-line line-number" line="3"><span class="token tag">  <span class="token attr-name">src</span><span class="token attr-value"><span class="token punctuation attr-equals">=</span><span class="token punctuation">"</span>https://app.justcall.io/app/macapp/dialer_events<span class="token punctuation">"</span></span>
 </span></span><span class="code-line line-number" line="4"><span class="token tag">  <span class="token special-attr"><span class="token attr-name">style</span><span class="token attr-value"><span class="token punctuation attr-equals">=</span><span class="token punctuation">"</span><span class="token value css language-css">width=<span class="token string">'365px'</span> height=<span class="token string">'610px'</span></span><span class="token punctuation">"</span></span></span>
 </span></span><span class="code-line line-number" line="5"><span class="token tag"><span class="token punctuation">></span></span>
 </span><span class="code-line line-number" line="6"><span class="token tag"><span class="token tag"><span class="token punctuation">&#x3C;/</span>iframe</span><span class="token punctuation">></span></span>
 </span></code><div onclick="copied(this)" data-code="<iframe
   allow=&#x22;microphone; autoplay; clipboard-read; clipboard-write; hid&#x22;
-  src=&#x22;ttps://app.justcall.io/app/macapp/dialer_events&#x22;
+  src=&#x22;https://app.justcall.io/app/macapp/dialer_events&#x22;
   style=&#x22;width=&#x27;365px&#x27; height=&#x27;610px&#x27;&#x22;
 >
 </iframe>

--- a/example/index.html
+++ b/example/index.html
@@ -1,52 +1,59 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Document</title>
-</head>
-<body>
+  </head>
+  <body>
     <script type="module">
-        import {JustCallDialer} from "./../dist/index.mjs"
-        
-        const dialer = new JustCallDialer({
-            dialerId: "justcall-dialer",
-            onLogin: (data) => {
-                console.log("Client receiving Logged in data: ", data)
-            },
-            onLogout: () => {
-                console.log("Client receiving Logged out")
-            },
-            onReady: () => {
-                console.log("Client receiving on ready callback")
-            }
-        })
+      import { JustCallDialer } from "./../dist/index.mjs";
 
-        dialer.on("call-ringing", data => {
-            console.log("Client receiving call-ringing data: ", data)
-        })
+      const dialer = new JustCallDialer({
+        dialerId: "justcall-dialer",
+        onLogin: (data) => {
+          console.log("Client receiving Logged in data: ", data);
+        },
+        onLogout: () => {
+          console.log("Client receiving Logged out");
+        },
+        onReady: () => {
+          console.log("Client receiving on ready callback");
+        },
+      });
 
-        dialer.on("call-answered", data => {
-            console.log("Client receiving call-answered data: ", data)
-        })
+      dialer.on("call-ringing", (data) => {
+        console.log("Client receiving call-ringing data: ", data);
+      });
 
-        dialer.on("call-ended",function(data) {
-            console.log("Client receiving call-ended data: ", data)
-        })
+      dialer.on("call-answered", (data) => {
+        console.log("Client receiving call-answered data: ", data);
+      });
 
-        console.log("Client receiving is dialer ready: ", dialer.isDialerReady);
+      dialer.on("call-ended", function (data) {
+        console.log("Client receiving call-ended data: ", data);
+      });
 
-        await dialer.ready();
+      dialer.on("sms-received", function (data) {
+        console.log("Client receiving sms-received data: ", data);
+      });
 
-        console.log("Client receiving is dialer ready: ", dialer.isDialerReady);
+      console.log("Client receiving is dialer ready: ", dialer.isDialerReady);
 
-        const isLoggedIn = await dialer.isLoggedIn();
+      await dialer.ready();
 
-        console.log("Client receiving is-logged-in data: ", isLoggedIn);
+      console.log("Client receiving is dialer ready: ", dialer.isDialerReady);
 
-        dialer.dialNumber("+123456789990");
+      const isLoggedIn = await dialer.isLoggedIn();
+
+      console.log("Client receiving is-logged-in data: ", isLoggedIn);
+
+      dialer.dialNumber("+123456789990");
     </script>
 
-    <div id="justcall-dialer" style="position:fixed; bottom:20px; right:20px;"></div>
-</body>
+    <div
+      id="justcall-dialer"
+      style="position: fixed; bottom: 20px; right: 20px"
+    ></div>
+  </body>
 </html>

--- a/src/dialer/justcall-client-event-emitter.ts
+++ b/src/dialer/justcall-client-event-emitter.ts
@@ -7,6 +7,7 @@ import {
   LoggedInEventData,
   LoginCallback,
   LogoutCallback,
+  SMSReceivedEventData,
 } from "../types";
 
 import { JustcallDialerErrorCode, handleError } from "../utils/errors";
@@ -62,5 +63,9 @@ export class JustCallClientEventEmitter {
 
   public handleCallEnded(data: CallEndedEventData): void {
     this.emit({ name: "call-ended", data });
+  }
+
+  public handleSMSReceived(data: SMSReceivedEventData): void {
+    this.emit({ name: "sms-received", data });
   }
 }

--- a/src/dialer/justcall-dialer-event-listener.ts
+++ b/src/dialer/justcall-dialer-event-listener.ts
@@ -7,6 +7,7 @@ import {
   LogoutCallback,
   JustCallDialerEvent,
   IsLoggedInData,
+  SMSReceivedEventData,
 } from "../types";
 import { JustCallClientEventEmitter } from "./justcall-client-event-emitter";
 
@@ -52,6 +53,7 @@ export class JustCallDialerEventListeners {
         | CallRingingEventData
         | CallAnsweredEventData
         | CallEndedEventData
+        | SMSReceivedEventData
         | IsLoggedInData;
     }>
   ): void => {
@@ -80,6 +82,11 @@ export class JustCallDialerEventListeners {
       case "call-ended":
         this.justcallClientEventEmitter.handleCallEnded(
           eventData as CallEndedEventData
+        );
+        break;
+      case "sms-received":
+        this.justcallClientEventEmitter.handleSMSReceived(
+          eventData as SMSReceivedEventData
         );
         break;
       case "is-logged-in": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,14 @@ export type CallEndedEventData = {
   duration: number;
 };
 
+export type SMSReceivedEventData = {
+  message_sid: string;
+  from: string;
+  to: string;
+  body: string;
+  received_at: string;
+};
+
 export type IsLoggedInData = (typeof isLoggedIn)[number];
 
 type EventDataType = {
@@ -56,12 +64,13 @@ type EventDataType = {
   "call-answered": CallAnsweredEventData;
   "call-ended": CallEndedEventData;
   "is-logged-in": IsLoggedInData;
+  "sms-received": SMSReceivedEventData;
 };
 
 type EventWithData<EventName extends keyof EventDataType> =
   EventName extends keyof EventDataType
-    ? { name: EventName; data: EventDataType[EventName] }
-    : never;
+  ? { name: EventName; data: EventDataType[EventName] }
+  : never;
 
 export type JustCallDialerEvent = (typeof validEvents)[number];
 

--- a/src/utils/contants.ts
+++ b/src/utils/contants.ts
@@ -8,6 +8,7 @@ export const validEmittableEvents = [
   "call-ringing",
   "call-answered",
   "call-ended",
+  "sms-received",
 ] as const;
 
 export const validEvents = [


### PR DESCRIPTION
# 🚀 feat: Added SMS Event - sms_received

This PR introduces SMS event handling capabilities to the JustCall Dialer SDK, allowing developers to listen for and handle SMS messages received through the dialer.

## ✨ What's New

- **New SMS Event**: Added `sms-received` event that triggers when an SMS is received
- **SMS Event Data Type**: Introduced `SMSReceivedEventData` interface with the following properties:
  - `message_sid` (string): Unique identifier for the SMS session
  - `from` (string): Phone number of the sender
  - `to` (string): Phone number of the receiver  
  - `body` (string): Content of the SMS message
  - `received_at` (string): Timestamp when the SMS was received

## 🔧 Technical Changes

### Core Implementation
- **`src/types.ts`**: Added `SMSReceivedEventData` type definition and updated event type mappings
- **`src/utils/contants.ts`**: Added `sms-received` to the list of valid emittable events
- **`src/dialer/justcall-client-event-emitter.ts`**: Added `handleSMSReceived()` method to emit SMS events
- **`src/dialer/justcall-dialer-event-listener.ts`**: Added SMS event handling in the event listener

### Documentation Updates
- **`README.md`**: 
  - Added `sms-received` event to the list of available events
  - Added usage example for SMS event handling
  - Added comprehensive documentation for `SMSReceivedEventData` type
  - Fixed typo in iframe src URL (changed `ttps://` to `https://`)

- **`docs/index.html`**: Updated generated documentation to include SMS event information

### Example Updates
- **`example/index.html`**: 
  - Added SMS event listener example
  - Improved code formatting and structure
  - Enhanced readability with proper indentation

## �� Usage Example

```javascript
const dialer = new JustCallDialer({
  dialerId: "justcall-dialer",
  // ... other options
});

// Listen for SMS events
dialer.on("sms-received", function (data) {
  console.log("Client receiving sms-received data: ", data);
  // data contains: message_sid, from, to, body, received_at
});
```

## 🎯 Benefits

- **Enhanced Communication**: Developers can now handle SMS messages alongside call events
- **Complete Event Coverage**: SDK now supports both voice and text communication events
- **Consistent API**: SMS events follow the same pattern as existing call events
- **Type Safety**: Full TypeScript support with proper type definitions

## 🔍 Testing

The implementation includes:
- Type safety through TypeScript interfaces
- Integration with existing event system architecture
- Backward compatibility with existing call events
- Proper error handling and validation

## 📋 Files Changed

- `.changeset/busy-hotels-lead.md` - Changeset for version bump
- `README.md` - Documentation updates and bug fix
- `docs/index.html` - Generated documentation
- `example/index.html` - Example code updates
- `src/dialer/justcall-client-event-emitter.ts` - SMS event emitter
- `src/dialer/justcall-dialer-event-listener.ts` - SMS event listener
- `src/types.ts` - Type definitions
- `src/utils/contants.ts` - Event constants

## 🐛 Bug Fix

- Fixed typo in iframe src URL from `ttps://` to `https://` in documentation

This enhancement maintains backward compatibility while extending the SDK's capabilities to handle SMS communication events, providing developers with a comprehensive solution for both voice and text communication handling.