### PR TITLE
FR-441 Copy Changes

### DIFF
--- a/.changeset/tangy-ghosts-sell.md
+++ b/.changeset/tangy-ghosts-sell.md
@@ -1,0 +1,5 @@
+---
+"@justcall/justcall-dialer-sdk": patch
+---
+
+docs: copy changes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Embed our JustCall CTI into your Platform for Instant Calling & Messaging
 
-This repository contains the TypeScript code for the JustCall Dialer SDK, which allows integration of [JustCall Dialer](https://app.justcall.io/dialer) functionality into web applications.
+This repository contains the TypeScript code for the JustCall CTI, which allows integration of [JustCall Dialer](https://app.justcall.io/dialer) functionality into web applications.
 
 You need a [JustCall](https://app.justcall.io/) account to be able to use the dialer and the following features.
 
@@ -28,7 +28,7 @@ pnpm add @justcall/justcall-dialer-sdk
 
 ## Constructor
 
-To use the JustCall Dialer SDK, you need to create an instance of the `JustCallDialer` class using its constructor. The constructor accepts an object with the following parameters:
+To use the JustCall CTI, you need to create an instance of the `JustCallDialer` class using its constructor. The constructor accepts an object with the following parameters:
 
 - `dialerId`: The id of the HTML element where the JustCall Dialer iframe will be embedded.
 - `onLogin`: A callback function triggered when the user logs in. It receives user details and integration settings, if any.
@@ -259,7 +259,7 @@ This data object is passed to the callback function when an SMS is received. It 
 
 ## Justcall Dialer Error Codes
 
-The `JustcallDialerErrorCode` enum provides error codes for handling various scenarios in the JustCall Dialer SDK.
+The `JustcallDialerErrorCode` enum provides error codes for handling various scenarios in the JustCall CTI.
 
 ### Error Codes:
 
@@ -269,10 +269,10 @@ The `JustcallDialerErrorCode` enum provides error codes for handling various sce
 - `not_subscribed_to_event`: This error occurs when attempting to unsubscribe from an event that you were not subscribed to in the first place.
 - `no_dialer_id`: This error occurs when no dialer ID is provided.
 - `dialer_id_not_found`: This error occurs when the specified dialer ID is not found.
-- `browser_environment_required`: This error occurs when the JustCall Dialer SDK is run in non-browser environments.
-- `unknown_error`: This error occurs when an unknown error is encountered during the operation of the JustCall Dialer SDK.
+- `browser_environment_required`: This error occurs when the JustCall CTI is run in non-browser environments.
+- `unknown_error`: This error occurs when an unknown error is encountered during the operation of the JustCall CTI.
 
-These error codes are useful for identifying and handling different error scenarios in the JustCall Dialer SDK.
+These error codes are useful for identifying and handling different error scenarios in the JustCall CTI.
 
 ## Authorizations for `<iframe>`
 
@@ -289,7 +289,7 @@ Please note that @justcall/justcall-dialer-sdk will produce an iframe with the f
 
 ## Contribution
 
-We welcome contributions from the community to improve the JustCall Dialer SDK. To contribute, follow these steps:
+We welcome contributions from the community to improve the JustCall CTI. To contribute, follow these steps:
 
 1. Make sure you have [PNPM](https://pnpm.io/) installed on your machine.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,11 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>@justcall/justcall-dialer-sdk</title>
+    <title>Embed our JustCall CTI into your Platform for Instant Calling &#x26; Messaging</title>
     <meta content="width=device-width, initial-scale=1" name="viewport">
-    <meta description="SDK for seamless integration and communication with the JustCall Dialer across diverse web environments.">
-    <meta keywords="Justcall SDK, @justcall/justcall-dialer-sdk, Justcall dialer sdk, Justcall NPM">
-    <meta description="SDK for seamless integration and communication with the JustCall Dialer across diverse web environments.">
+    <meta description="Integrate JustCall’s powerful CTI (Computer Telephony Integration) into your web platform to enable instant calling, and messaging—directly from your app. Our SDK makes it simple to embed a fully functional dialer and messaging system, ensuring seamless communication without switching tools.">
+    <meta keywords="Justcall SDK, @justcall/justcall-dialer-sdk, Justcall dialer sdk, Justcall NPM, JustCall CTI, embedded cloud phone system, in-app calling and messaging SDK, web telephony SDK, in-app VoIP and SMS solution">
+    <meta description="Integrate JustCall’s powerful CTI (Computer Telephony Integration) into your web platform to enable instant calling, and messaging—directly from your app. Our SDK makes it simple to embed a fully functional dialer and messaging system, ensuring seamless communication without switching tools.">
     <meta keywords="justcall,@justcall/justcall-dialer-sdk,justcall-dialer-sdk,justcall-dialer,justcall-dialer-npm,justcall-npm">
     <link rel="icon" href="https://cdn.justcall.io/app/assets/img/justcall-icon.svg" type="image/x-icon">
   </head>
@@ -159,8 +159,8 @@ class MarkdownStyle extends HTMLElement {
     }
 }
 customElements.define('markdown-style', MarkdownStyle);</script><markdown-style style="max-width: 960px; margin: 0 auto 60px auto; padding: 8px;max-width: 960px;" class="markdown-style">
-    <h1 id="justcall-sdk"><a class="anchor" aria-hidden="true" tabindex="-1" href="#justcall-sdk"><span class="octicon octicon-link"></span></a>JustCall SDK</h1>
-    <p>This repository contains the TypeScript code for the JustCall Dialer SDK, which allows integration of <a href="https://app.justcall.io/dialer">JustCall Dialer</a> functionality into web applications.</p>
+    <h1 id="embed-our-justcall-cti-into-your-platform-for-instant-calling--messaging"><a class="anchor" aria-hidden="true" tabindex="-1" href="#embed-our-justcall-cti-into-your-platform-for-instant-calling--messaging"><span class="octicon octicon-link"></span></a>Embed our JustCall CTI into your Platform for Instant Calling &#x26; Messaging</h1>
+    <p>This repository contains the TypeScript code for the JustCall CTI, which allows integration of <a href="https://app.justcall.io/dialer">JustCall Dialer</a> functionality into web applications.</p>
     <p>You need a <a href="https://app.justcall.io/">JustCall</a> account to be able to use the dialer and the following features.</p>
     <blockquote>
       <p><strong>Note</strong>: OAuth login through our SDK has been fixed and is now working properly across all versions of the SDK.</p>
@@ -179,7 +179,7 @@ customElements.define('markdown-style', MarkdownStyle);</script><markdown-style 
 </span></code><div onclick="copied(this)" data-code="pnpm add @justcall/justcall-dialer-sdk
 " class="copied"><svg class="octicon-copy" aria-hidden="true" viewBox="0 0 16 16" fill="currentColor" height="12" width="12"><path fill-rule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"></path><path fill-rule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"></path></svg><svg class="octicon-check" aria-hidden="true" viewBox="0 0 16 16" fill="currentColor" height="12" width="12"><path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path></svg></div></pre>
     <h2 id="constructor"><a class="anchor" aria-hidden="true" tabindex="-1" href="#constructor"><span class="octicon octicon-link"></span></a>Constructor</h2>
-    <p>To use the JustCall Dialer SDK, you need to create an instance of the <code>JustCallDialer</code> class using its constructor. The constructor accepts an object with the following parameters:</p>
+    <p>To use the JustCall CTI, you need to create an instance of the <code>JustCallDialer</code> class using its constructor. The constructor accepts an object with the following parameters:</p>
     <ul>
       <li><code>dialerId</code>: The id of the HTML element where the JustCall Dialer iframe will be embedded.</li>
       <li><code>onLogin</code>: A callback function triggered when the user logs in. It receives user details and integration settings, if any.</li>
@@ -435,7 +435,7 @@ dialer.dialNumber(&#x22;+1234567890&#x22;);
 }
 " class="copied"><svg class="octicon-copy" aria-hidden="true" viewBox="0 0 16 16" fill="currentColor" height="12" width="12"><path fill-rule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"></path><path fill-rule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"></path></svg><svg class="octicon-check" aria-hidden="true" viewBox="0 0 16 16" fill="currentColor" height="12" width="12"><path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path></svg></div></pre>
     <h2 id="justcall-dialer-error-codes"><a class="anchor" aria-hidden="true" tabindex="-1" href="#justcall-dialer-error-codes"><span class="octicon octicon-link"></span></a>Justcall Dialer Error Codes</h2>
-    <p>The <code>JustcallDialerErrorCode</code> enum provides error codes for handling various scenarios in the JustCall Dialer SDK.</p>
+    <p>The <code>JustcallDialerErrorCode</code> enum provides error codes for handling various scenarios in the JustCall CTI.</p>
     <h3 id="error-codes"><a class="anchor" aria-hidden="true" tabindex="-1" href="#error-codes"><span class="octicon octicon-link"></span></a>Error Codes:</h3>
     <ul>
       <li><code>invalid_event_name</code>: This error occurs when an invalid event name is provided.</li>
@@ -444,10 +444,10 @@ dialer.dialNumber(&#x22;+1234567890&#x22;);
       <li><code>not_subscribed_to_event</code>: This error occurs when attempting to unsubscribe from an event that you were not subscribed to in the first place.</li>
       <li><code>no_dialer_id</code>: This error occurs when no dialer ID is provided.</li>
       <li><code>dialer_id_not_found</code>: This error occurs when the specified dialer ID is not found.</li>
-      <li><code>browser_environment_required</code>: This error occurs when the JustCall Dialer SDK is run in non-browser environments.</li>
-      <li><code>unknown_error</code>: This error occurs when an unknown error is encountered during the operation of the JustCall Dialer SDK.</li>
+      <li><code>browser_environment_required</code>: This error occurs when the JustCall CTI is run in non-browser environments.</li>
+      <li><code>unknown_error</code>: This error occurs when an unknown error is encountered during the operation of the JustCall CTI.</li>
     </ul>
-    <p>These error codes are useful for identifying and handling different error scenarios in the JustCall Dialer SDK.</p>
+    <p>These error codes are useful for identifying and handling different error scenarios in the JustCall CTI.</p>
     <h2 id="authorizations-for-iframe"><a class="anchor" aria-hidden="true" tabindex="-1" href="#authorizations-for-iframe"><span class="octicon octicon-link"></span></a>Authorizations for <code>&#x3C;iframe></code></h2>
     <p>Please note that @justcall/justcall-dialer-sdk will produce an iframe with the following permissions granted:</p>
     <pre class="language-html"><code class="language-html code-highlight"><span class="code-line line-number" line="1"><span class="token tag"><span class="token tag"><span class="token punctuation">&#x3C;</span>iframe</span>
@@ -464,7 +464,7 @@ dialer.dialNumber(&#x22;+1234567890&#x22;);
 </iframe>
 " class="copied"><svg class="octicon-copy" aria-hidden="true" viewBox="0 0 16 16" fill="currentColor" height="12" width="12"><path fill-rule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"></path><path fill-rule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"></path></svg><svg class="octicon-check" aria-hidden="true" viewBox="0 0 16 16" fill="currentColor" height="12" width="12"><path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path></svg></div></pre>
     <h2 id="contribution"><a class="anchor" aria-hidden="true" tabindex="-1" href="#contribution"><span class="octicon octicon-link"></span></a>Contribution</h2>
-    <p>We welcome contributions from the community to improve the JustCall Dialer SDK. To contribute, follow these steps:</p>
+    <p>We welcome contributions from the community to improve the JustCall CTI. To contribute, follow these steps:</p>
     <ol>
       <li>
         <p>Make sure you have <a href="https://pnpm.io/">PNPM</a> installed on your machine.</p>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justcall/justcall-dialer-sdk",
   "version": "1.4.1",
-  "description": "SDK for seamless integration and communication with the JustCall Dialer across diverse web environments.",
+  "description": "Integrate JustCall’s powerful CTI (Computer Telephony Integration) into your web platform to enable instant calling, and messaging—directly from your app. Our SDK makes it simple to embed a fully functional dialer and messaging system, ensuring seamless communication without switching tools.",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -49,15 +49,15 @@
   },
   "markdown-to-html": {
     "document": {
-      "title": "@justcall/justcall-dialer-sdk",
-      "description": "SDK for seamless integration and communication with the JustCall Dialer across diverse web environments.",
+      "title": "Embed our JustCall CTI into your Platform for Instant Calling & Messaging",
+      "description": "Integrate JustCall’s powerful CTI (Computer Telephony Integration) into your web platform to enable instant calling, and messaging—directly from your app. Our SDK makes it simple to embed a fully functional dialer and messaging system, ensuring seamless communication without switching tools.",
       "style": "",
       "meta": [
         {
-          "description": "SDK for seamless integration and communication with the JustCall Dialer across diverse web environments."
+          "description": "Integrate JustCall’s powerful CTI (Computer Telephony Integration) into your web platform to enable instant calling, and messaging—directly from your app. Our SDK makes it simple to embed a fully functional dialer and messaging system, ensuring seamless communication without switching tools."
         },
         {
-          "keywords": "Justcall SDK, @justcall/justcall-dialer-sdk, Justcall dialer sdk, Justcall NPM"
+          "keywords": "Justcall SDK, @justcall/justcall-dialer-sdk, Justcall dialer sdk, Justcall NPM, JustCall CTI, embedded cloud phone system, in-app calling and messaging SDK, web telephony SDK, in-app VoIP and SMS solution"
         }
       ]
     },


### PR DESCRIPTION
`Header`: Embed our JustCall CTI into your Platform for Instant Calling & Messaging
`Description`: Integrate JustCall’s powerful CTI (Computer Telephony Integration) into your web platform to enable instant calling, and messaging—directly from your app. Our SDK makes it simple to embed a fully functional dialer and messaging system, ensuring seamless communication without switching tools.
`Keywords`: JustCall CTI, embedded cloud phone system, in-app calling and messaging SDK, web telephony SDK, in-app VoIP and SMS solution